### PR TITLE
Fix multiple eks clusters break same DNS zone

### DIFF
--- a/helm_external_dns.tf
+++ b/helm_external_dns.tf
@@ -18,6 +18,7 @@ resource "helm_release" "external_dns" {
         external_dns_eks_service_account = "${aws_iam_role.external_dns_role[0].name}",
         aws_iam_role_external_dns        = "${aws_iam_role.external_dns_role[0].name}",
         aws_iam_role_external_dns_arn    = "${aws_iam_role.external_dns_role[0].arn}",
+        eks_cluster_id                   = "${module.eks.cluster_id}",
       }
     )
   ]

--- a/helm_external_dns_private.tf
+++ b/helm_external_dns_private.tf
@@ -17,6 +17,7 @@ resource "helm_release" "external_dns_private" {
         external_dns_eks_service_account = "${aws_iam_role.external_dns_private_role[0].name}",
         aws_iam_role_external_dns        = "${aws_iam_role.external_dns_private_role[0].name}",
         aws_iam_role_external_dns_arn    = "${aws_iam_role.external_dns_private_role[0].arn}",
+        eks_cluster_id                   = "${module.eks.cluster_id}",
       }
     )
   ]

--- a/templates/external_dns_private_values.yaml
+++ b/templates/external_dns_private_values.yaml
@@ -17,3 +17,4 @@ serviceAccount:
     eks.amazonaws.com/role-arn: ${aws_iam_role_external_dns_arn}
 zoneIdFilters: ["${aws_private_hosted_zone}"]
 annotationFilter: "alb.ingress.kubernetes.io/scheme=internal"
+txtOwnerId: ${eks_cluster_id}

--- a/templates/external_dns_values.yaml
+++ b/templates/external_dns_values.yaml
@@ -17,3 +17,4 @@ serviceAccount:
     eks.amazonaws.com/role-arn: ${aws_iam_role_external_dns_arn}
 zoneIdFilters: ["${aws_public_hosted_zone}"]
 annotationFilter: "alb.ingress.kubernetes.io/scheme=internet-facing"
+txtOwnerId: ${eks_cluster_id}


### PR DESCRIPTION
Tested the change and it fixes the DNS issue we saw in Dev.

We use the `cluster-id` or cluster name as the namespace under which the sync of DNS names happen.

That way, the two clusters have separate records that don't conflict with each other while in `sync` mode. `my-cluster-1` is one namespace and `my-cluster-2` is another namespace and each cluster syncs into it's own namespace. In other words, `my-cluster-1` won't be able to touch records created by `my-cluster-2`.

```
my-cluster-1:
a.b.com
x.y.com

my-cluster-2:
c.d.com
u.v.com
```