### PR TITLE
Add EKS OIDC provider outputs

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -46,3 +46,17 @@ output "cluster_logs_bucket" {
   description = "Bucket for cluster logs."
   value       = var.create_logs_bucket == true ? aws_s3_bucket.logs_bucket[0].id : null
 }
+
+################################################################################
+# IRSA
+################################################################################
+
+output "oidc_url" {
+  description = "The OpenID Connect identity provider (issuer URL without leading `https://`)"
+  value       = module.eks.oidc_provider
+}
+
+output "oidc_provider_arn" {
+  description = "The ARN of the OIDC Provider if `enable_irsa = true`"
+  value       = module.eks.oidc_provider_arn
+}


### PR DESCRIPTION
To implement monitoring solution, we would need to interact with EKS OIDC provider to push metrics to AWS monitoring service like AWS Cloudwatch.  This PR prints results of oidc outputs that can referenced while deploying components that requires EKS OIDC  connection. 