### PR TITLE
Add support of installing aws-ebs-csi-driver.

### DIFF
--- a/addon_ebs_csi_driver.tf
+++ b/addon_ebs_csi_driver.tf
@@ -1,0 +1,43 @@
+data "aws_iam_policy_document" "ebs_csi_driver_irsa_assume_role_policy_doc" {
+  count = length(var.addon_ebs_csi_driver) == 0 ? 0 : 1
+
+  statement {
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+    effect  = "Allow"
+
+    principals {
+      type        = "Federated"
+      identifiers = [module.eks.oidc_provider_arn]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "${local.oidc_url}:sub"
+      values   = ["system:serviceaccount:kube-system:ebs-csi-controller-sa"]
+    }
+  }
+}
+
+resource "aws_iam_role" "ebs_csi_driver_irsa_role" {
+  count = length(var.addon_ebs_csi_driver) == 0 ? 0 : 1
+
+  name               = "${var.module_prefix}-ebs-csi-driver-irsa"
+  assume_role_policy = data.aws_iam_policy_document.ebs_csi_driver_irsa_assume_role_policy_doc[0].json
+}
+
+resource "aws_iam_role_policy_attachment" "ebs_csi_driver_irsa_policy_attachment" {
+  count = length(var.addon_ebs_csi_driver) == 0 ? 0 : 1
+
+  role       = aws_iam_role.ebs_csi_driver_irsa_role[0].name
+  policy_arn = "arn:${var.arn_format}:iam::aws:policy/service-role/AmazonEBSCSIDriverPolicy"
+}
+
+resource "aws_eks_addon" "ebs_csi_driver" {
+  count = length(var.addon_ebs_csi_driver) == 0 ? 0 : 1
+
+  cluster_name             = module.eks.cluster_id
+  service_account_role_arn = aws_iam_role.ebs_csi_driver_irsa_role[0].arn
+  addon_name               = var.addon_ebs_csi_driver["addon_name"]
+  addon_version            = lookup(var.addon_ebs_csi_driver, "addon_version", null)
+  resolve_conflicts        = lookup(var.addon_ebs_csi_driver, "resolve_conflicts", null)
+}

--- a/variables.tf
+++ b/variables.tf
@@ -107,6 +107,12 @@ EOF
   default     = "797873946194"
 }
 
+variable "addon_ebs_csi_driver" {
+  description = "Install Amazon EBS CSI driver add-on. Require for EKS cluster version 1.23 and above. For content, refer to 'aws_eks_addon' Terraform resource."
+  type        = map(string)
+  default     = {}
+}
+
 locals {
   eks_cluster_name       = "${var.module_prefix}-cluster"
   public_hosted_zone_id  = var.aws_public_hosted_zone == null ? "" : var.aws_public_hosted_zone


### PR DESCRIPTION
This was tested on a test cluster created with version `1.23`.